### PR TITLE
chore(general): run Prettier and ESLint on Husky pre-commit

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/*.test.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,13 @@
 {
   "root": true,
   "ignorePatterns": ["**/*"],
-  "plugins": ["@nrwl/nx", "@typescript-eslint"],
+  "plugins": ["@nrwl/nx", "@typescript-eslint", "prettier"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@nrwl/nx/typescript",
+    "plugin:@nrwl/nx/javascript",
+    "plugin:prettier/recommended"
+  ],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
@@ -22,21 +28,12 @@
       }
     },
     {
-      "files": ["*.ts", "*.tsx"],
-      "extends": ["plugin:@nrwl/nx/typescript"],
-      "rules": {}
-    },
-    {
-      "files": ["*.js", "*.jsx"],
-      "extends": ["plugin:@nrwl/nx/javascript"],
-      "rules": {}
-    },
-    {
       "files": ["*.spec.ts", "*.spec.tsx", "*.spec.js", "*.spec.jsx"],
       "env": {
         "jest": true
       },
       "rules": {}
     }
-  ]
+  ],
+  "rules": {}
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx nx run-many --target=lint --all
+npx lint-staged && echo 'Prettier formatting applied successfully!'

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  '*.{js,jsx,ts,tsx,json,html,css,md}': ['prettier --write', 'eslint --fix'],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx",
     "format": "prettier --write .",
     "prepare": "husky install",
-    "lint:prettier": "prettier --write --config .prettierrc --ignore-path .gitignore --quiet \"**/*.+(js|jsx|ts|tsx|html|json|css|scss)\"",
+    "lint:prettier": "prettier --write --config .prettierrc --ignore-path .gitignore --quiet \"**/*.+(js|jsx|ts|tsx|html|json|css|scss|md)\"",
     "fix": "npm run lint -- --fix",
     "release": "standard-version",
     "release:major": "standard-version --release-as major",
@@ -16,12 +16,6 @@
     "docusaurus:install": "cd ./docusaurus && npm install",
     "docusaurus:start": "cd ./docusaurus && npm start",
     "docusaurus:build-github": "bash build-docusaurus.bash"
-  },
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx,json,html,css,md}": [
-      "prettier --write",
-      "eslint --fix"
-    ]
   },
   "private": true,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
+    "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx",
+    "format": "prettier --write .",
     "prepare": "husky install",
-    "lint": "npx eslint",
+    "lint:prettier": "prettier --write --config .prettierrc --ignore-path .gitignore --quiet \"**/*.+(js|jsx|ts|tsx|html|json|css|scss)\"",
     "fix": "npm run lint -- --fix",
     "release": "standard-version",
     "release:major": "standard-version --release-as major",
@@ -14,6 +16,12 @@
     "docusaurus:install": "cd ./docusaurus && npm install",
     "docusaurus:start": "cd ./docusaurus && npm start",
     "docusaurus:build-github": "bash build-docusaurus.bash"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,json,html,css,md}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
   },
   "private": true,
   "devDependencies": {
@@ -54,11 +62,13 @@
     "eslint-plugin-cypress": "^2.10.3",
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-jsx-a11y": "6.7.1",
+    "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",
     "husky": "^8.0.3",
     "jest": "28.1.1",
     "jest-environment-jsdom": "28.1.1",
+    "lint-staged": "^13.2.0",
     "nx": "15.6.3",
     "passport": "^0.6.0",
     "prettier": "^2.6.2",


### PR DESCRIPTION
### **Task: Run prettier and ESLint pre-commit Husky**

https://app.clickup.com/t/860q4k8vt

Install and/or verify that the following dependencies exist in the project
```typescript
npm install --save-dev husky prettier eslint eslint-config-prettier eslint-plugin-prettier lint-staged

```

Configure ESLint and Prettier
In the .eslintrc.json file add Prettier in the plugins and add that plugin in the extends
```typescript
"plugins": ["@nrwl/nx", "@typescript-eslint", "prettier"],
"extends": [
    "eslint:recommended",
    "plugin:@nrwl/nx/typescript",
    "plugin:@nrwl/nx/javascript",
    "plugin:react/recommended",
    "plugin:prettier/recommended"
  ],

```

Create a lint-staged.config.js file in the root of the project with the following settings
```typescript
module.exports = {
  '*.{js,jsx,ts,tsx,json,html,css,md}': ['prettier --write', 'eslint --fix'],
};

```

Add the following line in the pre-commit file of the husky folder
```typescript
npx lint-staged && echo 'Prettier formatting applied successfully!'

```

Finally, in the scripts section of the package.json
```typescript
"scripts": {
  "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx",
  "format": "prettier --write .",
  "prepare": "husky install",
  "lint:prettier": "prettier --write --config .prettierrc --ignore-path .gitignore --quiet \"**/*.+(js|jsx|ts|tsx|html|json|css|scss|md)\"",
},

```
